### PR TITLE
Distinguish between global and matrix environment variables.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,12 @@ language: python
 python:
   - '2.7'
 env:
-  - DJANGO=1.4 DB=postgres
-  - DJANGO=1.5 DB=postgres
-  - DJANGO=1.6.2 DB=postgres
+  global:
+    - DB=postgres
+  matrix:
+    - DJANGO=1.4
+    - DJANGO=1.5
+    - DJANGO=1.6.2
 install:
   - pip install -q coverage pep8 pyflakes Django==$DJANGO
 before_script:


### PR DESCRIPTION
If a environment variable is declared on every row of the `env` section, it makes sense to label it as a `global` environment variable. This commit makes that change.

For a full description of how this works, see the docs: http://docs.travis-ci.com/user/build-configuration/#Environment-variables .
