### PR TITLE
Added django configuration to Sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,3 +132,9 @@ texinfo_documents = [
    u'{{ author_name }}', '{{ repo_name }}', 'A short description',
    'Miscellaneous'),
 ]
+
+# -- Django configuration -------------------------------------------------
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+from settings import configure_settings
+configure_settings()


### PR DESCRIPTION
@micahhausler I added django configuration so that Sphinx can be used to auto doc things that subclass Django models. The settings configuration may have to be done different for projects, but this works fine for our individual app structure
