### PR TITLE
Added publish.py

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -72,6 +72,8 @@ Before a new release, please go through the following checklist:
 * Add a release note in docs/release_notes.rst
 * Upload to pypi
 
+Uploading to pypi can be accomplished by running python publish.py
+
 Vulnerability Reporting
 -----------------------
 

--- a/publish.py
+++ b/publish.py
@@ -1,0 +1,5 @@
+import subprocess
+
+subprocess.call(['pip', 'install', 'wheel'])
+subprocess.call(['python', 'setup.py', 'clean', '--all'])
+subprocess.call(['python', 'setup.py', 'register', 'sdist', 'bdist_wheel', 'upload'])


### PR DESCRIPTION
@micahhausler I added a publish.py so that it is easier to not remember all the steps to publishing a package
